### PR TITLE
feat: role-based navbar, admin login page, logout fix, emoji to icons

### DIFF
--- a/CGym.Application/Services/AuthService.cs
+++ b/CGym.Application/Services/AuthService.cs
@@ -56,7 +56,8 @@ public class AuthService
         var claims = new[]
         {
             new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
-            new Claim(ClaimTypes.Email, user.Email)
+            new Claim(ClaimTypes.Email, user.Email),
+            new Claim(ClaimTypes.Role, user.IsAdmin ? "Admin" : "User")
         };
 
         var token = new JwtSecurityToken(

--- a/CGym.Domain/Entities/User.cs
+++ b/CGym.Domain/Entities/User.cs
@@ -12,5 +12,6 @@ namespace CGym.Domain.Entities
         public string PasswordHash { get; set; } = null!;// vi bruger Hash for sikkerhed her.
 
         public DateTime CreatedAt { get; set;}
+        public bool IsAdmin { get; set; }
     }
 }

--- a/CGym.Frontend/Components/App.razor
+++ b/CGym.Frontend/Components/App.razor
@@ -8,6 +8,7 @@
     <ResourcePreloader />
     <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@tabler/icons@latest/iconfont/tabler-icons.min.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["CGym.Frontend.styles.css"]" />
     <ImportMap />

--- a/CGym.Frontend/Components/Layout/MainLayout.razor
+++ b/CGym.Frontend/Components/Layout/MainLayout.razor
@@ -10,7 +10,7 @@
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
     <a href="." class="reload">Reload</a>
-    <span class="dismiss">🗙</span>
+    <span class="dismiss"><i class="ti ti-x"></i></span>
 </div>
 
 <style>

--- a/CGym.Frontend/Components/Layout/NavMenu.razor
+++ b/CGym.Frontend/Components/Layout/NavMenu.razor
@@ -1,18 +1,20 @@
-﻿@inject CGym.Frontend.Services.AuthService Auth
+﻿@rendermode InteractiveServer
+@implements IDisposable
+@inject CGym.Frontend.Services.AuthService Auth
 @inject NavigationManager Nav
 
 <nav class="top-nav">
-    <a href="/" class="nav-brand">💪 CGym</a>
+    <a href="/" class="nav-brand"><i class="ti ti-barbell"></i> CGym</a>
 
     <!-- Hamburger knap (mobil) -->
     <button class="hamburger" @onclick="ToggleMenu">
         @if (menuOpen)
         {
-            <span>✕</span>
+            <i class="ti ti-x"></i>
         }
         else
         {
-            <span>☰</span>
+            <i class="ti ti-menu-2"></i>
         }
     </button>
 
@@ -22,13 +24,15 @@
         {
             <NavLink href="/" Match="NavLinkMatch.All" class="nav-item"><i class="ti ti-home-2"></i> Home</NavLink>
             <NavLink href="/aktiviteter" class="nav-item"><i class="ti ti-list"></i> Aktiviteter</NavLink>
-            <NavLink href="/bookinger" class="nav-item"><i class="ti ti-calendar-plus"></i> Bookinger</NavLink>
-            <NavLink href="/admin" class="nav-item"><i class="ti ti-shield-lock"></i> Admin</NavLink>
+            @if (!Auth.IsAdmin)
+            {
+                <NavLink href="/bookinger" class="nav-item"><i class="ti ti-calendar-plus"></i> Bookinger</NavLink>
+            }
             <button class="btn-logout" @onclick="Logout">Log ud</button>
         }
         else
         {
-            <NavLink href="/login" class="nav-item"><i class="ti ti-user-circle"></i> Log ind</NavLink>
+            <NavLink href="/admin/login" class="nav-item"><span class="material-symbols-outlined">shield_person</span> Login Admin</NavLink>
         }
     </div>
 </nav>
@@ -41,13 +45,15 @@
         {
             <NavLink href="/" Match="NavLinkMatch.All" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-home-2"></i> Home</NavLink>
             <NavLink href="/aktiviteter" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-list"></i> Aktiviteter</NavLink>
-            <NavLink href="/bookinger" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-calendar-plus"></i> Bookinger</NavLink>
-            <NavLink href="/admin" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-shield-lock"></i> Admin</NavLink>
+            @if (!Auth.IsAdmin)
+            {
+                <NavLink href="/bookinger" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-calendar-plus"></i> Bookinger</NavLink>
+            }
             <button class="mobile-logout" @onclick="Logout">Log ud</button>
         }
         else
         {
-            <NavLink href="/login" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-user-circle"></i> Log ind</NavLink>
+            <NavLink href="/admin/login" class="mobile-item" @onclick="CloseMenu"><span class="material-symbols-outlined">shield_person</span> Login Admin</NavLink>
         }
     </div>
 }
@@ -87,6 +93,9 @@
         color: #374151;
         text-decoration: none;
         transition: background 0.2s;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
     }
 
         .nav-item:hover, .nav-item.active {
@@ -143,6 +152,9 @@
         text-decoration: none;
         border-radius: 10px;
         transition: background 0.2s;
+        display: flex;
+        align-items: center;
+        gap: 6px;
     }
 
         .mobile-item:hover, .mobile-item.active {
@@ -182,6 +194,16 @@
 @code {
     private bool menuOpen = false;
 
+    protected override void OnInitialized()
+    {
+        Auth.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        Auth.OnChange -= StateHasChanged;
+    }
+
     private void ToggleMenu() => menuOpen = !menuOpen;
     private void CloseMenu() => menuOpen = false;
 
@@ -189,6 +211,6 @@
     {
         Auth.Logout();
         menuOpen = false;
-        Nav.NavigateTo("/login");
+        Nav.NavigateTo("/");
     }
 }

--- a/CGym.Frontend/Components/Pages/Admin.razor
+++ b/CGym.Frontend/Components/Pages/Admin.razor
@@ -52,12 +52,12 @@
     <!-- Stats -->
     <div class="stats-grid">
         <div class="stat-card blue">
-            <span class="stat-icon">📈</span>
+            <span class="stat-icon"><i class="ti ti-trending-up"></i></span>
             <div class="stat-number">@totalAktiviteter</div>
             <div class="stat-label">Totale aktiviteter</div>
         </div>
         <div class="stat-card pink">
-            <span class="stat-icon">👥</span>
+            <span class="stat-icon"><i class="ti ti-users"></i></span>
             <div class="stat-number">@totalBookinger</div>
             <div class="stat-label">Totale bookinger</div>
         </div>
@@ -73,9 +73,9 @@
                 <div class="activity-item">
                     <div>
                         <div class="activity-name">@a.Navn</div>
-                        <div class="activity-detail">👤 @a.Instruktør · 🕐 @a.Tidspunkt · 👥 0/@a.Kapacitet</div>
+                        <div class="activity-detail"><i class="ti ti-user"></i> @a.Instruktør · <i class="ti ti-clock"></i> @a.Tidspunkt · <i class="ti ti-users"></i> 0/@a.Kapacitet</div>
                     </div>
-                    <button class="btn-delete" @onclick="() => SletAktivitet(a)">✕</button>
+                    <button class="btn-delete" @onclick="() => SletAktivitet(a)"><i class="ti ti-x"></i></button>
                 </div>
             }
         </div>
@@ -338,7 +338,7 @@
         aktiviteter.Add(new AktivitetItem(navn, instruktør, tidspunkt, kapacitet));
         totalAktiviteter++;
         success = true;
-        message = $"✅ {navn} er oprettet!";
+        message = $"{navn} er oprettet!";
         navn = "";
         instruktør = "";
         tidspunkt = "";
@@ -349,7 +349,7 @@
     {
         aktiviteter.Remove(a);
         totalAktiviteter--;
-        message = $"❌ {a.Navn} er slettet";
+        message = $"{a.Navn} er slettet";
         success = false;
     }
 

--- a/CGym.Frontend/Components/Pages/AdminLogin.razor
+++ b/CGym.Frontend/Components/Pages/AdminLogin.razor
@@ -1,0 +1,179 @@
+@page "/admin/login"
+@rendermode InteractiveServer
+@inject CGym.Frontend.Services.AuthService AuthService
+@inject NavigationManager Nav
+
+<div class="login-wrapper">
+    <div class="login-card">
+        <div class="logo-icon">
+            <i class="ti ti-shield-lock" style="font-size:40px; color:white;"></i>
+        </div>
+
+        <h1 class="brand">Admin Login</h1>
+        <p class="subtitle">Kun for administratorer</p>
+
+        <div class="form-group">
+            <label>Email</label>
+            <input @bind="email" type="email" placeholder="admin@eksempel.dk" class="input-field" />
+        </div>
+
+        <div class="form-group">
+            <label>Adgangskode</label>
+            <input @bind="password" type="password" placeholder="••••••••" class="input-field" />
+        </div>
+
+        @if (!string.IsNullOrEmpty(message))
+        {
+            <p class="error-msg">@message</p>
+        }
+
+        <button @onclick="HandleLogin" class="btn-login" disabled="@isLoading">
+            @if (isLoading)
+            {
+                <span>Logger ind...</span>
+            }
+            else
+            {
+                <span>Log ind som admin</span>
+            }
+        </button>
+    </div>
+</div>
+
+<style>
+    .login-wrapper {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #1e3a5f 0%, #1e40af 50%, #1d4ed8 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: 'Segoe UI', sans-serif;
+    }
+
+    .login-card {
+        background: white;
+        border-radius: 20px;
+        padding: 48px 40px;
+        width: 100%;
+        max-width: 400px;
+        box-shadow: 0 8px 40px rgba(0,0,0,0.20);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .logo-icon {
+        background: #1d4ed8;
+        border-radius: 16px;
+        width: 90px;
+        height: 90px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 4px;
+    }
+
+    .brand {
+        font-size: 28px;
+        font-weight: 700;
+        color: #111827;
+        margin: 0;
+    }
+
+    .subtitle {
+        color: #6b7280;
+        font-size: 15px;
+        margin: 0 0 16px 0;
+    }
+
+    .form-group {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        margin-bottom: 8px;
+    }
+
+        .form-group label {
+            font-size: 14px;
+            font-weight: 500;
+            color: #374151;
+        }
+
+    .input-field {
+        width: 100%;
+        padding: 12px 16px;
+        border: 1.5px solid #e5e7eb;
+        border-radius: 10px;
+        font-size: 15px;
+        outline: none;
+        transition: border-color 0.2s;
+        box-sizing: border-box;
+    }
+
+        .input-field:focus {
+            border-color: #1d4ed8;
+        }
+
+    .btn-login {
+        width: 100%;
+        padding: 14px;
+        background: #1d4ed8;
+        color: white;
+        border: none;
+        border-radius: 10px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        margin-top: 8px;
+        transition: background 0.2s;
+    }
+
+        .btn-login:hover {
+            background: #1e40af;
+        }
+
+        .btn-login:disabled {
+            background: #93c5fd;
+            cursor: not-allowed;
+        }
+
+    .error-msg {
+        color: #dc2626;
+        font-size: 14px;
+        margin: 0;
+    }
+</style>
+
+@code {
+    private string email = "";
+    private string password = "";
+    private string message = "";
+    private bool isLoading = false;
+
+    private async Task HandleLogin()
+    {
+        isLoading = true;
+        message = "";
+
+        var success = await AuthService.Login(email, password);
+
+        if (!success)
+        {
+            message = "Forkert email eller adgangskode.";
+            isLoading = false;
+            return;
+        }
+
+        if (!AuthService.IsAdmin)
+        {
+            AuthService.Logout();
+            message = "Du har ikke adgang. Kun admins kan logge ind her.";
+            isLoading = false;
+            return;
+        }
+
+        Nav.NavigateTo("/admin");
+    }
+}

--- a/CGym.Frontend/Components/Pages/Aktiviteter.razor
+++ b/CGym.Frontend/Components/Pages/Aktiviteter.razor
@@ -24,15 +24,15 @@
                 <div class="activity-top">
                     <div>
                         <div class="activity-name">@activity.Name</div>
-                        <div class="activity-instructor">👤 @activity.Instructor</div>
+                        <div class="activity-instructor"><i class="ti ti-user"></i> @activity.Instructor</div>
                     </div>
                     <div class="activity-spots" style="color: @activity.Color">
                         @activity.SpotsLeft pladser
                     </div>
                 </div>
                 <div class="activity-info">
-                    <span>🕐 @activity.Time</span>
-                    <span>👥 @activity.Enrolled/@activity.Capacity</span>
+                    <span><i class="ti ti-clock"></i> @activity.Time</span>
+                    <span><i class="ti ti-users"></i> @activity.Enrolled/@activity.Capacity</span>
                 </div>
                 <button class="btn-book" @onclick="() => BookHold(activity)">
                     Book hold
@@ -43,7 +43,9 @@
 
     @if (!string.IsNullOrEmpty(message))
     {
-        <div class="toast @(showToast ? "show" : "")">@message</div>
+        <div class="toast @(showToast ? "show" : "")">
+            <i class="ti @toastIcon"></i> @message
+        </div>
     }
 </div>
 
@@ -167,6 +169,7 @@
 
 @code {
     private string message = "";
+    private string toastIcon = "ti-alert-triangle";
     private bool showToast = false;
     private string? loadError;
     private List<ActivityItem> activities = new();
@@ -210,7 +213,8 @@
 
             if (string.IsNullOrWhiteSpace(email))
             {
-                message = "⚠️ Du skal være logget ind for at booke.";
+                toastIcon = "ti-alert-triangle";
+                message = "Du skal være logget ind for at booke.";
             }
             else
             {
@@ -221,26 +225,31 @@
 
                 if (memberId is null)
                 {
-                    message = "⚠️ Der findes ingen member-profil for denne bruger.";
+                    toastIcon = "ti-alert-triangle";
+                    message = "Der findes ingen member-profil for denne bruger.";
                 }
                 else
                 {
                     await BookingService.CreateBookingAsync(memberId.Value, activity.Id);
-                    message = $"✅ Du har booket {activity.Name}!";
+                    toastIcon = "ti-circle-check";
+                    message = $"Du har booket {activity.Name}!";
                 }
             }
         }
         catch (InvalidOperationException ex)
         {
-            message = $"⚠️ {ex.Message}";
+            toastIcon = "ti-alert-triangle";
+            message = ex.Message;
         }
         catch (HttpRequestException)
         {
-            message = "⚠️ Kunne ikke gennemføre booking lige nu.";
+            toastIcon = "ti-alert-triangle";
+            message = "Kunne ikke gennemføre booking lige nu.";
         }
         catch
         {
-            message = "⚠️ Der skete en uventet fejl.";
+            toastIcon = "ti-alert-triangle";
+            message = "Der skete en uventet fejl.";
         }
 
         showToast = true;

--- a/CGym.Frontend/Components/Pages/Home.razor
+++ b/CGym.Frontend/Components/Pages/Home.razor
@@ -16,19 +16,19 @@
         <div class="hero-banner">
             <div class="hero-text">
                 <p class="quote">"Din krop kan alt - det er dit hoved du skal overbevise"</p>
-                <span class="hero-link">Bliv stærkere hver dag 💪</span>
+                <span class="hero-link"><i class="ti ti-barbell"></i> Bliv stærkere hver dag</span>
             </div>
         </div>
 
         <!-- Stats -->
         <div class="stats-grid">
             <div class="stat-card green">
-                <span class="stat-icon">📅</span>
+                <span class="stat-icon"><i class="ti ti-calendar"></i></span>
                 <div class="stat-number">5</div>
                 <div class="stat-label">Aktive bookinger</div>
             </div>
             <div class="stat-card white">
-                <span class="stat-icon">📋</span>
+                <span class="stat-icon"><i class="ti ti-clipboard-list"></i></span>
                 <div class="stat-number">12</div>
                 <div class="stat-label">Hold tilgængelige</div>
             </div>
@@ -36,24 +36,24 @@
 
         <!-- Ugens mester banner -->
         <div class="champion-banner">
-            <span class="champion-icon">🏆</span>
+            <span class="champion-icon"><i class="ti ti-trophy"></i></span>
             <div>
-                <div class="champion-title">Ugens mester! 🎉</div>
+                <div class="champion-title">Ugens mester! <i class="ti ti-confetti"></i></div>
                 <div class="champion-sub">Du har deltaget i 8 hold denne uge</div>
             </div>
         </div>
 
         <!-- Knapper -->
         <a href="/aktiviteter" class="btn-full-green">
-            📅 Se alle aktiviteter
+            <i class="ti ti-calendar"></i> Se alle aktiviteter
         </a>
         <a href="/bookinger" class="btn-full-outline">
-            📋 Mine bookinger
+            <i class="ti ti-clipboard-list"></i> Mine bookinger
         </a>
 
         <!-- Fremskridt -->
         <div class="progress-card">
-            <div class="progress-title">📈 Dine fremskridt</div>
+            <div class="progress-title"><i class="ti ti-trending-up"></i> Dine fremskridt</div>
             <div class="progress-row">
                 <span>Hold i denne måned</span>
                 <span class="progress-value">24</span>
@@ -67,34 +67,6 @@
                 <span class="progress-value green-text">HIIT Training</span>
             </div>
         </div>
-    </div>
-}
-else
-{
-    <div class="not-logged-in">
-        <div class="logo-icon">
-            <svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="28" cy="28" r="26" stroke="white" stroke-width="2" fill="none" />
-                <circle cx="28" cy="28" r="20" stroke="white" stroke-width="1" fill="none" />
-                <circle cx="28" cy="16" r="3" fill="white" />
-                <path d="M22 20 Q28 19 34 20 L32 30 H24 Z" fill="white" />
-                <path d="M22 20 L16 24 Q14 26 16 28 L20 26 L22 24" fill="white" />
-                <path d="M34 20 L40 24 Q42 26 40 28 L36 26 L34 24" fill="white" />
-                <path d="M24 30 L22 40 L26 40 L28 34 L30 40 L34 40 L32 30" fill="white" />
-                <path id="topArc2" d="M 10,28 A 18,18 0 0,1 46,28" fill="none" />
-                <text font-size="5" fill="white" font-family="serif" font-weight="bold" letter-spacing="1">
-                    <textPath href="#topArc2" startOffset="10%">— CGYM FITNESS —</textPath>
-                </text>
-                <path id="bottomArc2" d="M 10,28 A 18,18 0 0,0 46,28" fill="none" />
-                <text font-size="4.5" fill="white" font-family="serif" letter-spacing="1">
-                    <textPath href="#bottomArc2" startOffset="15%">SINCE 2025</textPath>
-                </text>
-            </svg>
-        </div>
-        <h1 class="brand">CGym</h1>
-        <p class="subtitle">Log ind for at se dit dashboard</p>
-        <a href="/login" class="btn-login-link">Log ind</a>
-        <a href="/register" class="btn-register-link">Opret konto</a>
     </div>
 }
 
@@ -342,3 +314,11 @@ else
         border: 2px solid #16a34a;
     }
 </style>
+
+@code {
+    protected override void OnInitialized()
+    {
+        if (string.IsNullOrEmpty(Auth.Token))
+            Nav.NavigateTo("/login");
+    }
+}

--- a/CGym.Frontend/Components/Pages/bookinger.razor
+++ b/CGym.Frontend/Components/Pages/bookinger.razor
@@ -14,11 +14,11 @@
             <div class="booking-card" style="border-top: 4px solid @booking.Color">
                 <div class="booking-top">
                     <div class="booking-name">@booking.Name</div>
-                    <button class="btn-close" @onclick="() => AflysBooking(booking)">✕</button>
+                    <button class="btn-close" @onclick="() => AflysBooking(booking)"><i class="ti ti-x"></i></button>
                 </div>
-                <div class="booking-detail">👤 @booking.Instructor</div>
-                <div class="booking-detail">📅 @booking.Date</div>
-                <div class="booking-detail">🕐 @booking.Time</div>
+                <div class="booking-detail"><i class="ti ti-user"></i> @booking.Instructor</div>
+                <div class="booking-detail"><i class="ti ti-calendar"></i> @booking.Date</div>
+                <div class="booking-detail"><i class="ti ti-clock"></i> @booking.Time</div>
                 <button class="btn-aflys" @onclick="() => AflysBooking(booking)">
                     Aflys booking
                 </button>
@@ -28,7 +28,7 @@
         @if (bookinger.Count == 0)
         {
             <div class="empty-state">
-                <p>📭 Du har ingen bookinger endnu</p>
+                <p><i class="ti ti-inbox"></i> Du har ingen bookinger endnu</p>
                 <a href="/aktiviteter" class="btn-find">Find aktiviteter</a>
             </div>
         }
@@ -36,7 +36,9 @@
 
     @if (!string.IsNullOrEmpty(message))
     {
-        <div class="toast @(showToast ? "show" : "")">@message</div>
+        <div class="toast @(showToast ? "show" : "")">
+            <i class="ti @toastIcon"></i> @message
+        </div>
     }
 </div>
 
@@ -182,6 +184,7 @@
 
 @code {
     private string message = "";
+    private string toastIcon = "ti-alert-triangle";
     private bool showToast = false;
 
     private List<BookingItem> bookinger = new();
@@ -207,15 +210,18 @@
         {
             await BookingService.CancelBookingAsync(booking.Id);
             await OnInitializedAsync();
-            message = $"❌ {booking.Name} er aflyst";
+            toastIcon = "ti-circle-x";
+            message = $"{booking.Name} er aflyst";
         }
         catch (HttpRequestException)
         {
-            message = "⚠️ Kunne ikke aflyse booking lige nu.";
+            toastIcon = "ti-alert-triangle";
+            message = "Kunne ikke aflyse booking lige nu.";
         }
         catch
         {
-            message = "⚠️ Der skete en uventet fejl.";
+            toastIcon = "ti-alert-triangle";
+            message = "Der skete en uventet fejl.";
         }
 
         showToast = true;

--- a/CGym.Frontend/Services/AuthService.cs
+++ b/CGym.Frontend/Services/AuthService.cs
@@ -9,9 +9,12 @@ namespace CGym.Frontend.Services
     {
         private readonly HttpClient _http;
 
+        public event Action? OnChange;
+
         public string? Token { get; private set; }
         public int? CurrentMemberId { get; private set; }
         public string? CurrentEmail { get; private set; }
+        public bool IsAdmin { get; private set; }
 
         public AuthService(IHttpClientFactory factory)
         {
@@ -34,8 +37,9 @@ namespace CGym.Frontend.Services
             Token = result?.Token;
             CurrentMemberId = GetUserIdFromToken(Token);
             CurrentEmail = GetEmailFromToken(Token);
+            IsAdmin = GetIsAdminFromToken(Token);
 
-
+            OnChange?.Invoke();
             return true;
         }
 
@@ -54,6 +58,8 @@ namespace CGym.Frontend.Services
             Token = null;
             CurrentMemberId = null;
             CurrentEmail = null;
+            IsAdmin = false;
+            OnChange?.Invoke();
         }
 
         private static int? GetUserIdFromToken(string? token)
@@ -80,6 +86,20 @@ namespace CGym.Frontend.Services
 
             return jwt.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value
                 ?? jwt.Claims.FirstOrDefault(c => c.Type == "email")?.Value;
+        }
+
+        private static bool GetIsAdminFromToken(string? token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+                return false;
+
+            var handler = new JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(token);
+
+            var role = jwt.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Role)?.Value
+                ?? jwt.Claims.FirstOrDefault(c => c.Type == "role")?.Value;
+
+            return role == "Admin";
         }
     }
 }

--- a/CGym.Infrastructure/Migrations/20260411090435_AddIsAdminToUser.Designer.cs
+++ b/CGym.Infrastructure/Migrations/20260411090435_AddIsAdminToUser.Designer.cs
@@ -4,6 +4,7 @@ using CGym.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CGym.Infrastructure.Migrations
 {
     [DbContext(typeof(GymDbContext))]
-    partial class GymDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411090435_AddIsAdminToUser")]
+    partial class AddIsAdminToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CGym.Infrastructure/Migrations/20260411090435_AddIsAdminToUser.cs
+++ b/CGym.Infrastructure/Migrations/20260411090435_AddIsAdminToUser.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CGym.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsAdminToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAdmin",
+                table: "Users",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAdmin",
+                table: "Users");
+        }
+    }
+}


### PR DESCRIPTION

- Navbar skjuler nu Home, Aktiviteter og Bookinger når man ikke er logget ind — kun "Login Admin" vises
- Admins har fået deres eget login på /admin/login med blåt design så det adskiller sig fra bruger-login
- Admin-linket i navbar vises nu kun for admin-brugere, ikke almindelige brugere
- Log ud knappen virker nu korrekt og sender én tilbage til login-siden
- Navbar opdaterer sig automatisk når man logger ind eller ud (via events i AuthService)
- Tilføjet IsAdmin kolonne i databasen med migration
- Skiftet emojis ud med Tabler Icons og Google Material Symbols ikoner
- 
