### PR TITLE
Admin: Hent og slet aktiviteter

### DIFF
--- a/CGym.Frontend/Components/Layout/NavMenu.razor
+++ b/CGym.Frontend/Components/Layout/NavMenu.razor
@@ -22,8 +22,8 @@
     <div class="nav-links desktop">
         @if (!string.IsNullOrEmpty(Auth.Token))
         {
-            <NavLink href="/" Match="NavLinkMatch.All" class="nav-item"><i class="ti ti-home-2"></i> Home</NavLink>
-            <NavLink href="/aktiviteter" class="nav-item"><i class="ti ti-list"></i> Aktiviteter</NavLink>
+            <NavLink href="@(Auth.IsAdmin ? "/admin" : "/")" Match="NavLinkMatch.All" class="nav-item"><i class="ti ti-home-2"></i> Home</NavLink>
+            <NavLink href="@(Auth.IsAdmin ? "/admin/aktiviteter" : "/aktiviteter")" class="nav-item"><i class="ti ti-list"></i> Aktiviteter</NavLink>
             @if (!Auth.IsAdmin)
             {
                 <NavLink href="/bookinger" class="nav-item"><i class="ti ti-calendar-plus"></i> Bookinger</NavLink>
@@ -43,8 +43,8 @@
     <div class="mobile-menu">
         @if (!string.IsNullOrEmpty(Auth.Token))
         {
-            <NavLink href="/" Match="NavLinkMatch.All" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-home-2"></i> Home</NavLink>
-            <NavLink href="/aktiviteter" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-list"></i> Aktiviteter</NavLink>
+            <NavLink href="@(Auth.IsAdmin ? "/admin" : "/")" Match="NavLinkMatch.All" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-home-2"></i> Home</NavLink>
+            <NavLink href="@(Auth.IsAdmin ? "/admin/aktiviteter" : "/aktiviteter")" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-list"></i> Aktiviteter</NavLink>
             @if (!Auth.IsAdmin)
             {
                 <NavLink href="/bookinger" class="mobile-item" @onclick="CloseMenu"><i class="ti ti-calendar-plus"></i> Bookinger</NavLink>

--- a/CGym.Frontend/Components/Pages/Admin.razor
+++ b/CGym.Frontend/Components/Pages/Admin.razor
@@ -71,23 +71,6 @@
         </div>
     </div>
 
-    <!-- Aktivitetsliste -->
-    @if (aktiviteter.Count > 0)
-    {
-        <div class="activity-list">
-            <h3 class="list-title">Oprettede aktiviteter</h3>
-            @foreach (var a in aktiviteter)
-            {
-                <div class="activity-item">
-                    <div>
-                        <div class="activity-name">@a.Navn</div>
-                        <div class="activity-detail"><i class="ti ti-user"></i> @a.Instruktør · <i class="ti ti-clock"></i> @a.Tidspunkt · <i class="ti ti-users"></i> 0/@a.Kapacitet</div>
-                    </div>
-                    <button class="btn-delete" @onclick="() => SletAktivitet(a)"><i class="ti ti-x"></i></button>
-                </div>
-            }
-        </div>
-    }
 </div>
 
 <style>
@@ -305,20 +288,44 @@
         margin-top: 4px;
     }
 
-    .btn-delete {
-        background: none;
+    .admin-actions {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+
+    .btn-edit {
+        padding: 8px 12px;
         border: none;
-        color: #9ca3af;
-        font-size: 16px;
+        border-radius: 8px;
+        background: #2563eb;
+        color: white;
+        font-size: 13px;
+        font-weight: 600;
         cursor: pointer;
-        padding: 4px 8px;
-        border-radius: 6px;
-        transition: color 0.2s;
+        transition: background 0.2s;
+    }
+
+        .btn-edit:hover {
+            background: #1d4ed8;
+        }
+
+    .btn-delete {
+        padding: 8px 12px;
+        border: none;
+        border-radius: 8px;
+        background: #dc2626;
+        color: white;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s;
     }
 
         .btn-delete:hover {
-            color: #ef4444;
+            background: #b91c1c;
         }
+
 </style>
 
 @code {
@@ -340,11 +347,24 @@
         try
         {
             trainers = await TrainerService.GetTrainersAsync();
+
+            var apiActivities = await ActivityService.GetActivitiesAsync();
+
+            aktiviteter = apiActivities
+                .Select(a => new AktivitetItem(
+                    a.Id,
+                    a.Name,
+                    a.Trainer?.Name ?? "Ikke angivet",
+                    a.StartTime.ToString("dd-MM-yyyy HH:mm"),
+                    a.Capacity))
+                .ToList();
+
+                totalAktiviteter = aktiviteter.Count; 
         }
         catch
         {
             success = false;
-            message = "Kunne ikke hente træner.";
+            message = "Kunne ikke hente data.";
         }
 
     }
@@ -387,13 +407,23 @@
 
     }
 
-    private void SletAktivitet(AktivitetItem a)
+    private async Task SletAktivitet(AktivitetItem a)
     {
-        aktiviteter.Remove(a);
-        totalAktiviteter--;
-        message = $"{a.Navn} er slettet";
-        success = false;
+        try
+        {
+            await ActivityService.DeleteActivityAsync(a.Id);
+            aktiviteter.Remove(a);
+            totalAktiviteter = aktiviteter.Count;
+            success = true;
+            message = $"{a.Navn} er slettet.";
+        }
+        catch
+        {
+            success = false;
+            message = "Kunne ikke slette aktivitet via API.";
+        }
     }
 
-    private record AktivitetItem(string Navn, string Instruktør, string Tidspunkt, int Kapacitet);
+
+    private record AktivitetItem(int Id, string Navn, string Trainer, string Tidspunkt, int Kapacitet);
 }

--- a/CGym.Frontend/Components/Pages/AdminAktiviteter.razor
+++ b/CGym.Frontend/Components/Pages/AdminAktiviteter.razor
@@ -1,16 +1,12 @@
-﻿@page "/aktiviteter"
+﻿@page "/admin/aktiviteter"
 @rendermode InteractiveServer
-@inject CGym.Frontend.Services.BookingService BookingService
 @inject CGym.Frontend.Services.ActivityService ActivityService
-@inject CGym.Frontend.Services.AuthService AuthService
-@inject CGym.Frontend.Services.MemberService MemberService
 
 <div class="aktiviteter-wrapper">
     <div class="page-header">
-        <a href="/" class="back-btn">← </a>
         <h2 class="page-title">Aktiviteter</h2>
     </div>
-    <p class="page-sub">Find og book dine yndlings træningshold</p>
+    <p class="page-sub">Administrer centerets aktiviteter</p>
 
     @if (!string.IsNullOrWhiteSpace(loadError))
     {
@@ -30,16 +26,17 @@
                         @activity.SpotsLeft pladser
                     </div>
                 </div>
+
                 <div class="activity-info">
-                    <span><i class="ti ti-clock"></i> @activity.Time</span>
                     <span><i class="ti ti-calendar"></i> @activity.Date</span>
+                    <span><i class="ti ti-clock"></i> @activity.Time</span>
                     <span><i class="ti ti-users"></i> @activity.Enrolled/@activity.Capacity</span>
                 </div>
 
-                    <button class="btn-book" @onclick="() => BookHold(activity)">
-                        Book hold
-                    </button>
-                
+                <div class="admin-actions">
+                    <button class="btn-edit" type="button" @onclick="() => StartRedigering(activity)">Rediger</button>
+                    <button class="btn-delete" @onclick="() => SletAktivitet(activity)">Slet aktivitet</button>
+                </div>
             </div>
         }
     </div>
@@ -65,12 +62,6 @@
         align-items: center;
         gap: 12px;
         margin-bottom: 4px;
-    }
-
-    .back-btn {
-        font-size: 20px;
-        color: #111827;
-        text-decoration: none;
     }
 
     .page-title {
@@ -132,23 +123,40 @@
         color: #6b7280;
     }
 
-    .btn-book {
-        width: 100%;
+    .admin-actions {
+        display: flex;
+        gap: 10px;
+        margin-top: 6px;
+    }
+
+    .btn-edit,
+    .btn-delete {
+        flex: 1;
         padding: 14px;
-        background: #16a34a;
-        color: white;
         border: none;
         border-radius: 10px;
         font-size: 15px;
         font-weight: 600;
         cursor: pointer;
+        color: white;
         transition: background 0.2s;
     }
 
-    
-    .btn-book:hover {
-        background: #15803d;
+    .btn-edit {
+        background: #2563eb;
     }
+
+        .btn-edit:hover {
+            background: #1d4ed8;
+        }
+
+    .btn-delete {
+        background: #dc2626;
+    }
+
+        .btn-delete:hover {
+            background: #b91c1c;
+        }
 
     .toast {
         position: fixed;
@@ -210,51 +218,20 @@
         }
     }
 
-    private async Task BookHold(ActivityItem activity)
+    private async Task SletAktivitet(ActivityItem activity)
     {
         try
         {
-            var email = AuthService.CurrentEmail;
+            await ActivityService.DeleteActivityAsync(activity.Id);
+            activities.Remove(activity);
 
-            if (string.IsNullOrWhiteSpace(email))
-            {
-                toastIcon = "ti-alert-triangle";
-                message = "Du skal være logget ind for at booke.";
-            }
-            else
-            {
-                var members = await MemberService.GetMembersAsync();
-                var memberId = members
-                    .FirstOrDefault(m => m.Email.Equals(email, StringComparison.OrdinalIgnoreCase))
-                    ?.Id;
-
-                if (memberId is null)
-                {
-                    toastIcon = "ti-alert-triangle";
-                    message = "Der findes ingen member-profil for denne bruger.";
-                }
-                else
-                {
-                    await BookingService.CreateBookingAsync(memberId.Value, activity.Id);
-                    toastIcon = "ti-circle-check";
-                    message = $"Du har booket {activity.Name}!";
-                }
-            }
-        }
-        catch (InvalidOperationException ex)
-        {
-            toastIcon = "ti-alert-triangle";
-            message = ex.Message;
-        }
-        catch (HttpRequestException)
-        {
-            toastIcon = "ti-alert-triangle";
-            message = "Kunne ikke gennemføre booking lige nu.";
+            toastIcon = "ti-circle-check";
+            message = $"{activity.Name} er slettet.";
         }
         catch
         {
             toastIcon = "ti-alert-triangle";
-            message = "Der skete en uventet fejl.";
+            message = "Kunne ikke slette aktivitet lige nu.";
         }
 
         showToast = true;
@@ -265,8 +242,15 @@
         StateHasChanged();
     }
 
+    private void StartRedigering(ActivityItem activity)
+    {
+        toastIcon = "ti-circle-check";
+        message = $"Du redigerer nu: {activity.Name}";
+        showToast = true;
+    }
 
-    private record ActivityItem(int Id, string Name, string Instructor, string Time,String Date, int Capacity, int Enrolled, string Color)
+
+    private record ActivityItem(int Id, string Name, string Instructor, string Date, string Time, int Capacity, int Enrolled, string Color)
     {
         public int SpotsLeft => Capacity - Enrolled;
     }

--- a/CGym.Frontend/Components/Pages/bookinger.razor
+++ b/CGym.Frontend/Components/Pages/bookinger.razor
@@ -16,7 +16,7 @@
                     <div class="booking-name">@booking.Name</div>
                     <button class="btn-close" @onclick="() => AflysBooking(booking)"><i class="ti ti-x"></i></button>
                 </div>
-                <div class="booking-detail"><i class="ti ti-user"></i> @booking.Instructor</div>
+                <div class="booking-detail"><i class="ti ti-user"></i> @booking.Trainer</div>
                 <div class="booking-detail"><i class="ti ti-calendar"></i> @booking.Date</div>
                 <div class="booking-detail"><i class="ti ti-clock"></i> @booking.Time</div>
                 <button class="btn-aflys" @onclick="() => AflysBooking(booking)">
@@ -232,5 +232,5 @@
         StateHasChanged();
     }
 
-    private record BookingItem(int Id, string Name, string Instructor, string Date, string Time, string Color);
+    private record BookingItem(int Id, string Name, string Trainer, string Date, string Time, string Color);
 }

--- a/CGym.Frontend/Services/ActivityService.cs
+++ b/CGym.Frontend/Services/ActivityService.cs
@@ -23,6 +23,12 @@ namespace CGym.Frontend.Services
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<ActivityApiModel>(); 
         }
+
+        public async Task DeleteActivityAsync (int id)
+        {
+            var response = await _http.DeleteAsync($"api/activity/{id}");
+            response.EnsureSuccessStatusCode();
+        }
     }
 
     public class ActivityApiModel


### PR DESCRIPTION
Opdateret admin-flow for aktiviteter. Admin henter aktiviteter fra API ved load, kan slette via DELETE /api/activity/{id}, og navigation er justeret så admin går til admin-sider.